### PR TITLE
Restored functionality in the kitchen view

### DIFF
--- a/app/src/main/java/se/miun/dt170/antonsskafferi/ui/bong/BongItemView.java
+++ b/app/src/main/java/se/miun/dt170/antonsskafferi/ui/bong/BongItemView.java
@@ -72,7 +72,7 @@ public class BongItemView extends ConstraintLayout implements View.OnClickListen
     }
 
     private void setItemClicked() {
-        //bongListView = (BongListView) this.getParent();
+        bongListView = (BongListView) this.getParent();
 
         if (!itemClicked) {
             this.setBackgroundColor(Color.parseColor("#a0f4a0")); //light green


### PR DESCRIPTION
Having all bong list items checked didn't hide the bong any more. Fixed.